### PR TITLE
Feat：添加列表页面标签状态的 URL 参数支持

### DIFF
--- a/src/pages/bounties/all.tsx
+++ b/src/pages/bounties/all.tsx
@@ -1,19 +1,20 @@
-import { Box, Flex } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 
-import { EmptySection } from '@/components/shared/EmptySection';
-import {
-  ListingCard,
-  ListingCardSkeleton,
-  ListingSection,
-  listingsQuery,
-} from '@/features/listings';
+import { listingsQuery, ListingTabs } from '@/features/listings';
 import { Home } from '@/layouts/Home';
+import { dayjs } from '@/utils/dayjs';
 
 export default function AllBountiesPage() {
+  const deadline = useMemo(
+    () => dayjs().subtract(2, 'months').toISOString(),
+    [],
+  );
   const { data: listings, isLoading } = useQuery(
     listingsQuery({
       type: 'bounty',
+      deadline,
       take: 100,
     }),
   );
@@ -21,29 +22,14 @@ export default function AllBountiesPage() {
   return (
     <Home type="listing">
       <Box w={'100%'} pr={{ base: 0, lg: 6 }}>
-        <ListingSection
-          type="bounties"
-          title="赏金任务"
-          sub=""
+        <ListingTabs
+          bounties={listings}
+          isListingsLoading={isLoading}
           emoji=""
-        >
-          {isLoading &&
-            Array.from({ length: 8 }, (_, index) => (
-              <ListingCardSkeleton key={index} />
-            ))}
-          {!isLoading && !listings?.length && (
-            <Flex align="center" justify="center" mt={8}>
-              <EmptySection
-                title="No listings available!"
-                message="Update your email preferences (from the user menu) to be notified about new work opportunities."
-              />
-            </Flex>
-          )}
-          {!isLoading &&
-            listings?.map((bounty) => (
-              <ListingCard key={bounty.id} bounty={bounty} />
-            ))}
-        </ListingSection>
+          title="赏金任务"
+          viewAllLink="/bounties/all"
+          showViewAll={false}
+        />
       </Box>
     </Home>
   );

--- a/src/pages/category/[slug]/all.tsx
+++ b/src/pages/category/[slug]/all.tsx
@@ -2,18 +2,25 @@ import { Box } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import type { NextPageContext } from 'next';
 import { useRouter } from 'next/router';
+import { useMemo } from 'react';
 
 import { listingsQuery, ListingTabs } from '@/features/listings';
 import { Home } from '@/layouts/Home';
 import { Meta } from '@/layouts/Meta';
+import { dayjs } from '@/utils/dayjs';
 
 type SlugKeys = 'design' | 'content' | 'development' | 'other';
 
 function AllCategoryListingsPage({ slug }: { slug: string }) {
   const router = useRouter();
+  const deadline = useMemo(
+    () => dayjs().subtract(1, 'month').toISOString(),
+    [],
+  );
   const { data: listings, isLoading } = useQuery(
     listingsQuery({
       filter: slug,
+      deadline,
       take: 100,
     }),
   );

--- a/src/pages/projects/all.tsx
+++ b/src/pages/projects/all.tsx
@@ -1,19 +1,20 @@
-import { Box, Flex } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 
-import { EmptySection } from '@/components/shared/EmptySection';
-import {
-  ListingCard,
-  ListingCardSkeleton,
-  ListingSection,
-  listingsQuery,
-} from '@/features/listings';
+import { listingsQuery, ListingTabs } from '@/features/listings';
 import { Home } from '@/layouts/Home';
+import { dayjs } from '@/utils/dayjs';
 
 export default function AllProjectsPage() {
+  const deadline = useMemo(
+    () => dayjs().subtract(2, 'months').toISOString(),
+    [],
+  );
   const { data: listings, isLoading } = useQuery(
     listingsQuery({
       type: 'project',
+      deadline,
       take: 100,
     }),
   );
@@ -21,29 +22,14 @@ export default function AllProjectsPage() {
   return (
     <Home type="listing">
       <Box w={'100%'}>
-        <ListingSection
-          type="bounties"
-          title="定向任务"
-          sub="开启您的定向任务之旅"
+        <ListingTabs
+          bounties={listings}
+          isListingsLoading={isLoading}
           emoji=""
-        >
-          {isLoading &&
-            Array.from({ length: 8 }, (_, index) => (
-              <ListingCardSkeleton key={index} />
-            ))}
-          {!isLoading && !listings?.length && (
-            <Flex align="center" justify="center" mt={8}>
-              <EmptySection
-                title="暂无可用任务!"
-                message="更新您的电子邮件偏好设置（从用户菜单），以便接收关于新任务的通知"
-              />
-            </Flex>
-          )}
-          {!isLoading &&
-            listings?.map((bounty) => (
-              <ListingCard key={bounty.id} bounty={bounty} />
-            ))}
-        </ListingSection>
+          title="定向任务"
+          viewAllLink="/projects/all"
+          showViewAll={false}
+        />
       </Box>
     </Home>
   );


### PR DESCRIPTION
## 总结

这次修改为列表页面添加了 URL 参数支持，允许用户通过 URL 直接访问特定的标签状态（进行中/审核中/已完成），并修复了标签切换时的闪烁问题。

  主要改进包括：
  - ✅ 支持 URL 参数直接访问特定标签
  - ✅ 修复标签切换闪烁问题
  - ✅ 统一所有列表页面的用户体验
  - ✅ 提供可分享的链接功能

## 文件修改

### 1. src/features/listings/components/ListingTabs.tsx

  主要修改：
  - 添加了 useRef 导入用于初始化标志
  - 实现了 URL 参数与标签状态的双向同步
  - 修复了标签切换时的闪烁问题
  - 添加了渲染保护避免初始化时的闪烁

  具体改动：
  // 添加 useRef 导入
  import { useEffect, useRef, useState } from 'react';

  // 修改状态初始化，避免默认值闪烁
  const [activeTab, setActiveTab] = useState<string>('');

  // 添加初始化标志
  const isInitialized = useRef(false);

  // 简化初始化逻辑，统一处理 URL 参数
  useEffect(() => {
    const tabParam = router.query.tab as string;
    const tabMap: Record<string, string> = {
      open: 'tab1',
      review: 'tab2',
      completed: 'tab3',
    };

    const initialTab = tabParam && tabMap[tabParam] ? tabMap[tabParam] : tabs[0]!.id;
    setActiveTab(initialTab);
    isInitialized.current = true;
  }, [router.query.tab]);

  // 添加渲染保护
  if (!activeTab) {
    return <Box mt={5} mb={10} />;
  }

  ### 2. src/pages/bounties/all.tsx

  修改内容：
  - 使用 ListingTabs 组件替换原有的列表展示
  - 设置 2 个月的时间范围过滤
  - 添加中文标题"赏金任务"

  关键改动：
  // 使用 ListingTabs 组件
  <ListingTabs
    bounties={listings}
    isListingsLoading={isLoading}
    emoji=""
    title="赏金任务"
    viewAllLink="/bounties/all"
    showViewAll={false}
  />

 ### 3. src/pages/projects/all.tsx

  修改内容：
  - 使用 ListingTabs 组件统一列表展示
  - 设置 2 个月的时间范围过滤
  - 添加中文标题"定向任务"

  ### 4. src/pages/category/[slug]/all.tsx

  修改内容：
  - 已正确配置 deadline 参数（1个月前）
  - 使用 ListingTabs 组件并设置合适的参数
  - 标题为"自由职业"

  ##  新增功能

  1. URL 参数支持
    - 支持 ?tab=open 显示"进行中"标签
    - 支持 ?tab=review 显示"审核中"标签
    - 支持 ?tab=completed 显示"已完成"标签
  2. 可分享的链接
    - 用户可以分享带有特定标签状态的链接
    - 访问链接时直接显示对应的标签内容
  3. 统一的用户体验
    - 所有列表页面使用相同的组件和交互
    - 标签切换更流畅，无闪烁

  ##  修复的问题

  1. 标签切换闪烁
    - 添加初始化标志避免竞争条件
    - 优化状态管理，确保平滑切换
  2. URL 同步问题
    - 修复了 URL 参数与标签状态不同步的问题
    - 确保用户操作后 URL 正确更新

  ## 可测试

  测试以下场景：
  1. 直接访问带有 tab 参数的 URL：
    - /category/design/all?tab=review
    - /bounties/all?tab=completed
    - /projects/all?tab=open
  2. 在页面中点击不同标签，确认：
    - 标签切换无闪烁
    - URL 正确更新
    - "查看全部"按钮链接包含当前标签状态
  3. 刷新页面后，确认保持在当前标签
