### PR TITLE
Fix: 统一首页和全部页面的任务过滤逻辑

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -156,11 +156,14 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
     });
   }
 
+  const tab = context.query.tab as string;
+  
   const openListings = await getListings({
     statusFilter: 'open',
     order: 'desc',
     userRegion,
     excludeIds: openForYouListings.map((listing) => listing.id),
+    tab,
   });
 
   return {

--- a/src/pages/sponsor/edit.tsx
+++ b/src/pages/sponsor/edit.tsx
@@ -220,7 +220,7 @@ const UpdateSponsor = () => {
                   fontWeight={600}
                   htmlFor={'slug'}
                 >
-                  组织 Username
+                  自定义网址后缀（Slug）
                 </FormLabel>
                 <Input
                   w={'full'}
@@ -406,7 +406,7 @@ const UpdateSponsor = () => {
                 fontSize={'15px'}
                 fontWeight={600}
               >
-                公司 Logo{' '}
+                组织Logo{' '}
                 <span
                   style={{
                     color: 'red',
@@ -496,7 +496,7 @@ const UpdateSponsor = () => {
                   fontWeight={600}
                   htmlFor={'bio'}
                 >
-                  公司简介
+                  组织简介
                 </FormLabel>
                 <Input
                   w={'full'}
@@ -506,7 +506,7 @@ const UpdateSponsor = () => {
                   id="bio"
                   maxLength={180}
                   {...register('bio')}
-                  placeholder="您的公司做什么？"
+                  placeholder="您的组织做什么？"
                 />
                 <Text
                   color={


### PR DESCRIPTION
## 总结

- 修改 homepage listings API 支持 tab 参数                                       
- 当 tab=open 时使用与 /api/listings 相同的宽松过滤逻辑                             
- 移除地区、薪酬、语言和黑客马拉松奖励的严格限制                                 
- 保持向后兼容性，默行为不变                                                 
- 解决 "/?tab=open" 显示空任务列表的问题  

## 具体

修改内容包括：

 ###  1. 修改了 /src/pages/api/homepage/listings.ts：

  - 添加了 tab 参数支持
  - 当 tab=open 时，移除了严格的过滤条件（地区、薪酬、语言、黑客马拉松奖励）
  - 保持了向后兼容性（默认行为不变）

 ###  2. 修改了 /src/pages/index.tsx：

  - 在 getServerSideProps 中读取 URL 的 tab 参数
  - 将 tab 参数传递给 getListings API

  主要改动：

  - 首页 API 现在支持 tab=open 参数，此时会使用与 /api/listings 相同的宽松过滤逻辑
  - 保持了向后兼容性，没有 tab 参数时仍使用原有的严格过滤
  - 用户体验现在一致，"/?tab=open" 和 "/all/?tab=open" 会显示相同的任务列表

  这样修改后，当用户访问 "/?tab=open" 时，应该能看到所有开放的任务，而不是空列表。

