### PR TITLE
Fix: 修复获胜者状态徽章不显示的问题

### DIFF
--- a/src/features/listings/components/SubmissionsPage/Badge.tsx
+++ b/src/features/listings/components/SubmissionsPage/Badge.tsx
@@ -11,22 +11,23 @@ export const Badge = ({
 }: {
   position: keyof Rewards | undefined;
 }) => {
-  if (position === BONUS_REWARD_POSITION) return <></>;
-  position = Number(position);
+  if (!position) return <></>;
+  
+  const positionNum = Number(position);
+  if (positionNum === BONUS_REWARD_POSITION) return <></>;
+  
   return (
     <HStack
       w="fit-content"
       h="1.2rem"
       px={2}
-      color={position === 1 ? '#D97706' : '#475569'}
+      color={positionNum === 1 ? '#D97706' : '#475569'}
       fontSize="sm"
-      bg={position === 1 ? '#FFF7ED' : '#F8FAFC'}
+      bg={positionNum === 1 ? '#FFF7ED' : '#F8FAFC'}
       rounded="full"
     >
       <StarIcon h={3} w={3} />
-      {position !== BONUS_REWARD_POSITION && (
-        <Text>{nthLabelGenerator(position ?? 0)}</Text>
-      )}
+      <Text>{nthLabelGenerator(positionNum)}</Text>
     </HStack>
   );
 };


### PR DESCRIPTION

  ## 问题

  在悬赏任务系统中，当赞助方选出获胜者后，后台虽然能看到颜色区分，但获胜者的状态标识（1st、2nd、3rd）没有显示。

 ## 根本原因

  在 Badge.tsx 组件中，代码在比较 position === BONUS_REWARD_POSITION 时，没有将 position 参数转换为数字类型。由于 position
  是作为字符串类型的键从 Rewards 类型传入的，导致类型比较失败，所有获胜者的徽章都被错误地隐藏了。

## 修复方案

  修改了 /src/features/listings/components/SubmissionsPage/Badge.tsx 文件：
  1. 添加了空值检查：if (!position) return <></>;
  2. 提前将 position 转换为数字：const positionNum = Number(position);
  3. 使用转换后的数字进行正确比较
  4. 移除了冗余的条件判断

  ## 影响范围

  - 修复了所有悬赏任务获胜者状态显示问题
  - 确保 1st、2nd、3rd 及其他排名位置正确显示
  - 不影响现有功能和颜色样式

  ## 测试建议

  - 查看有获胜者的悬赏任务页面
  - 确认获胜者徽章正确显示排名（1st、2nd、3rd）
  - 验证颜色样式保持正常