### PR TITLE
Fix:获奖页面移动端适配

### DIFF
--- a/src/features/listings/components/ListingPage/ListingWinners.tsx
+++ b/src/features/listings/components/ListingPage/ListingWinners.tsx
@@ -19,12 +19,20 @@ import { EarnAvatar } from '@/features/talent';
 import { type SubmissionWithUser } from '@/interface/submission';
 import { tweetEmbedLink } from '@/utils/socialEmbeds';
 
+import { listingWinnersQuery } from '../../queries/listing-winners';
+import type { Listing, Rewards } from '../../types';
+import { tweetTemplate } from '../../utils';
+
+interface Props {
+  bounty: Listing;
+}
+
 const getRankLabel = (position: number | null | undefined) => {
   if (!position && position !== 0) return '';
   if (position === BONUS_REWARD_POSITION) return 'bonus';
 
   const suffixes = ['th', 'st', 'nd', 'rd', 'th'];
-  const relevantDigits = position % 100;
+  const relevantDigits = (position as number) % 100;
   const suffix =
     relevantDigits >= 11 && relevantDigits <= 13
       ? 'th'
@@ -39,27 +47,14 @@ const getRewardAmount = (
 ) => {
   if (!bounty?.rewards || position === undefined || position === null)
     return '';
-
-  if (position === BONUS_REWARD_POSITION) {
-    const bonusAmount = bounty?.rewards?.bonus ?? 0;
-    return bonusAmount > 0
-      ? `${formatTotalPrice(bonusAmount)} ${bounty?.token || ''}`.trim()
-      : '';
-  }
+  // Rewards 类型内无 bonus 字段；bonus 不展示金额
+  if (position === BONUS_REWARD_POSITION) return '';
 
   const amount = bounty?.rewards[Number(position) as keyof Rewards] ?? 0;
   return amount > 0
     ? `${formatTotalPrice(amount)} ${bounty?.token || ''}`.trim()
     : '';
 };
-
-import { listingWinnersQuery } from '../../queries/listing-winners';
-import type { Listing, Rewards } from '../../types';
-import { tweetTemplate } from '../../utils';
-
-interface Props {
-  bounty: Listing;
-}
 
 const getOrRemoveBonuses = (
   submissions: SubmissionWithUser[],
@@ -69,15 +64,11 @@ const getOrRemoveBonuses = (
     return submissions.filter(
       (s) => s.winnerPosition !== BONUS_REWARD_POSITION,
     );
-  else
-    return submissions.filter(
-      (s) => s.winnerPosition === BONUS_REWARD_POSITION,
-    );
+  return submissions.filter((s) => s.winnerPosition === BONUS_REWARD_POSITION);
 };
 
 export function ListingWinners({ bounty }: Props) {
   const isProject = bounty?.type === 'project';
-
   const posthog = usePostHog();
   const isMD = useBreakpointValue({ base: false, md: true });
 
@@ -85,31 +76,34 @@ export function ListingWinners({ bounty }: Props) {
     listingWinnersQuery(bounty?.id),
   );
 
-  const openWinnerLink = () => {
-    let path = window.location.href.split('?')[0];
-    if (!path) return;
-    path += 'winner/';
-
-    return tweetEmbedLink(tweetTemplate(path));
-  };
+  const openWinnerLink = () =>
+    tweetEmbedLink(
+      tweetTemplate(
+        `https://earn.superteam.fun/listing/${bounty?.slug}/winner`,
+      ),
+    );
 
   if (isLoading || !submissions.length) {
     return null;
   }
 
-  // Sort submissions by winnerPosition
   const sortedSubmissions = [...submissions].sort((a, b) => {
     const posA = a.winnerPosition ?? Infinity;
     const posB = b.winnerPosition ?? Infinity;
     return posA - posB;
   });
 
+  const tailSubmissions = [
+    ...getOrRemoveBonuses(sortedSubmissions, true).slice(3),
+    ...getOrRemoveBonuses(sortedSubmissions, false),
+  ];
+
   return (
     <Box
       pos="relative"
       w="full"
-      maxW={'7xl'}
-      mx={'auto'}
+      maxW="7xl"
+      mx="auto"
       px={4}
       pt={4}
       bg="#F5F3FF"
@@ -124,12 +118,13 @@ export function ListingWinners({ bounty }: Props) {
         >
           🎉 Winners
         </Text>
+
         <NextLink href={openWinnerLink() ?? '#'} target="_blank">
           <Button
             className="ph-no-capture"
             gap={2}
             display="flex"
-            w={'auto'}
+            w="auto"
             h="min-content"
             px={{ base: 2, md: 3 }}
             py={{ base: 1.5, md: 2 }}
@@ -160,12 +155,12 @@ export function ListingWinners({ bounty }: Props) {
           </Button>
         </NextLink>
       </HStack>
+
       <Box mx={3} mt={{ base: 2, md: 0 }}>
         <Box
           w="full"
           px={{ base: 3, md: 4 }}
           py={{ base: 4, md: 4 }}
-          color="white"
           rounded="md"
         >
           <Flex
@@ -190,78 +185,58 @@ export function ListingWinners({ bounty }: Props) {
                     as="a"
                     align="center"
                     justify="center"
-                    direction={'column'}
+                    direction="column"
                     cursor="pointer"
                   >
-                    <Box pos="relative">
-                      {!isProject &&
-                        submission?.winnerPosition !==
-                          BONUS_REWARD_POSITION && (
-                          <Center
-                            pos="absolute"
-                            zIndex={1}
-                            bottom={2}
-                            left="50%"
-                            w={{ base: 8, md: 10 }}
-                            h={{ base: 5, md: 6 }}
-                            px={1}
-                            color="brand.slate.500"
-                            fontSize={{ base: '2xs', md: 'xx-small' }}
-                            fontWeight={600}
-                            textAlign="center"
-                            textTransform="capitalize"
-                            bg="#fff"
-                            border="1px solid"
-                            borderColor="brand.slate.300"
-                            transform="translateX(-50%)"
-                            rounded={'full'}
-                          >
-                            {getRankLabel(submission?.winnerPosition)}
-                          </Center>
-                        )}
-                      {!isProject &&
-                        submission?.winnerPosition ===
-                          BONUS_REWARD_POSITION && (
-                          <Center
-                            pos="absolute"
-                            zIndex={1}
-                            bottom={2}
-                            left="50%"
-                            w={{ base: 8, md: 10 }}
-                            h={{ base: 5, md: 6 }}
-                            px={1}
-                            color="brand.slate.500"
-                            fontSize={{ base: '2xs', md: 'xx-small' }}
-                            fontWeight={600}
-                            textAlign="center"
-                            textTransform="capitalize"
-                            bg="#fff"
-                            border="1px solid"
-                            borderColor="brand.slate.300"
-                            transform="translateX(-50%)"
-                            rounded={'full'}
-                          >
-                            bonus
-                          </Center>
-                        )}
+                    <Box
+                      pos="relative"
+                      overflow="visible"
+                      pb={{ base: 5, md: 6 }}
+                    >
+                      {!isProject && (
+                        <Center
+                          pos="absolute"
+                          zIndex={2}
+                          bottom="-6px"
+                          left="50%"
+                          h="1.2rem"
+                          px={2}
+                          color="brand.slate.500"
+                          fontSize="sm"
+                          fontWeight={600}
+                          textAlign="center"
+                          textTransform="capitalize"
+                          bg="#fff"
+                          border="1px solid"
+                          borderColor="brand.slate.300"
+                          transform="translateX(-50%)"
+                          pointerEvents="none"
+                          rounded="full"
+                        >
+                          {getRankLabel(submission?.winnerPosition)}
+                        </Center>
+                      )}
+
                       <EarnAvatar
                         size={isMD ? '64px' : '52px'}
                         id={submission?.user?.id}
                         avatar={submission?.user?.photo as string}
                       />
                     </Box>
+
                     <Text
                       w={{ base: 'min-content', md: 'auto' }}
                       pt={4}
                       color="brand.slate.700"
                       fontSize={{ base: 'xs', md: 'sm' }}
                       fontWeight={600}
-                      textAlign={'center'}
+                      textAlign="center"
                       noOfLines={2}
                     >{`${submission?.user?.firstName} ${submission?.user?.lastName}`}</Text>
+
                     <Text
                       color="brand.slate.500"
-                      fontSize={'xs'}
+                      fontSize="xs"
                       fontWeight={400}
                       textAlign="center"
                       opacity={0.6}
@@ -274,6 +249,7 @@ export function ListingWinners({ bounty }: Props) {
           </Flex>
         </Box>
       </Box>
+
       {(getOrRemoveBonuses(sortedSubmissions, true).length > 3 ||
         getOrRemoveBonuses(sortedSubmissions, false).length > 0) && (
         <HStack
@@ -285,16 +261,16 @@ export function ListingWinners({ bounty }: Props) {
           borderColor="#DDD6FE"
           borderTopWidth="1px"
         >
-          {[
-            ...getOrRemoveBonuses(sortedSubmissions, true).slice(3),
-            ...getOrRemoveBonuses(sortedSubmissions, false),
-          ].map((submission) => (
+          {tailSubmissions.map((submission) => (
             <Box key={submission.id} pos="relative">
               <Tooltip
-                label={`${submission?.user?.firstName} ${submission?.user?.lastName} (${submission?.winnerPosition === BONUS_REWARD_POSITION ? 'bonus' : getRankLabel(submission?.winnerPosition)})`}
+                label={`${submission?.user?.firstName} ${submission?.user?.lastName}${
+                  submission?.winnerPosition === BONUS_REWARD_POSITION
+                    ? ' (bonus)'
+                    : ''
+                }`}
               >
                 <Link
-                  key={submission.id}
                   as={NextLink}
                   href={
                     !isProject
@@ -304,52 +280,30 @@ export function ListingWinners({ bounty }: Props) {
                   passHref
                 >
                   <Box pos="relative">
-                    {!isProject &&
-                      submission?.winnerPosition !== BONUS_REWARD_POSITION && (
-                        <Center
-                          pos="absolute"
-                          zIndex={1}
-                          bottom={0}
-                          left="50%"
-                          w={{ base: 5, md: 6 }}
-                          h={{ base: 3.5, md: 4 }}
-                          px={0.5}
-                          color="brand.slate.500"
-                          fontSize={{ base: '3xs', md: '3xs' }}
-                          fontWeight={600}
-                          textAlign="center"
-                          bg="#fff"
-                          border="1px solid"
-                          borderColor="brand.slate.300"
-                          transform="translateX(-50%)"
-                          rounded={'full'}
-                        >
-                          {getRankLabel(submission?.winnerPosition)}
-                        </Center>
-                      )}
-                    {!isProject &&
-                      submission?.winnerPosition === BONUS_REWARD_POSITION && (
-                        <Center
-                          pos="absolute"
-                          zIndex={1}
-                          bottom={0}
-                          left="50%"
-                          w={{ base: 5, md: 6 }}
-                          h={{ base: 3.5, md: 4 }}
-                          px={0.5}
-                          color="brand.slate.500"
-                          fontSize={{ base: '3xs', md: '3xs' }}
-                          fontWeight={600}
-                          textAlign="center"
-                          bg="#fff"
-                          border="1px solid"
-                          borderColor="brand.slate.300"
-                          transform="translateX(-50%)"
-                          rounded={'full'}
-                        >
-                          bonus
-                        </Center>
-                      )}
+                    {submission?.winnerPosition === BONUS_REWARD_POSITION && (
+                      <Center
+                        pos="absolute"
+                        zIndex={2}
+                        bottom="-4px"
+                        left="50%"
+                        w={{ base: 5, md: 6 }}
+                        h={{ base: 3.5, md: 4 }}
+                        px={0.5}
+                        color="brand.slate.500"
+                        fontSize="3xs"
+                        fontWeight={600}
+                        textAlign="center"
+                        bg="#fff"
+                        border="1px solid"
+                        borderColor="brand.slate.300"
+                        transform="translateX(-50%)"
+                        pointerEvents="none"
+                        rounded="full"
+                      >
+                        bonus
+                      </Center>
+                    )}
+
                     <EarnAvatar
                       size={isMD ? '44px' : '36px'}
                       id={submission?.user?.id}
@@ -363,7 +317,6 @@ export function ListingWinners({ bounty }: Props) {
         </HStack>
       )}
 
-      {/* Add some bottom padding for better spacing */}
       <Box pb={2} />
     </Box>
   );


### PR DESCRIPTION
## 本次修改内容

- 1st/2nd/3rd 徽章底部居中、微微探出（bottom="-6px"），不会挡脸
- 前三名头像：52px / 64px
- 下排：头像尺寸 36/44，有 tooltip；若是 bonus 会有小角标
- 分享按钮用 slug 的绝对链接，可正常跳转发推