### PR TITLE
Fix:错误页面配置

### DIFF
--- a/src/features/listings/components/ListingTabs.tsx
+++ b/src/features/listings/components/ListingTabs.tsx
@@ -1,4 +1,4 @@
-import { ArrowForwardIcon, InfoOutlineIcon } from '@chakra-ui/icons';
+import { ArrowForwardIcon } from '@chakra-ui/icons';
 import { Box, Button, Flex, HStack, Image, Link, Text } from '@chakra-ui/react';
 import dynamic from 'next/dynamic';
 import NextLink from 'next/link';
@@ -6,9 +6,6 @@ import { useRouter } from 'next/router';
 import { usePostHog } from 'posthog-js/react';
 import { useEffect, useRef, useState } from 'react';
 
-import { Tooltip } from '@/components/shared/responsive-tooltip';
-import { type User } from '@/interface/user';
-import { useUser } from '@/store/user';
 import { dayjs } from '@/utils/dayjs';
 
 import { type Listing } from '../types';
@@ -23,7 +20,6 @@ interface TabProps {
 interface ListingTabsProps {
   isListingsLoading: boolean;
   bounties: Listing[] | undefined;
-  forYou?: Listing[] | undefined;
   take?: number;
   emoji?: string;
   title: string;
@@ -33,16 +29,13 @@ interface ListingTabsProps {
 }
 
 interface ContentProps {
-  title: string;
   bounties?: Listing[];
-  forYou?: Listing[];
   take?: number;
   isListingsLoading: boolean;
   filterFunction: (bounty: Listing) => boolean;
   sortCompareFunction?: ((a: Listing, b: Listing) => number) | undefined;
   emptyTitle: string;
   emptyMessage: string;
-  user: User | null;
   showNotifSub?: boolean;
 }
 
@@ -53,117 +46,43 @@ const EmptySection = dynamic(
 );
 
 const generateTabContent = ({
-  title,
   bounties,
-  forYou,
   take,
   isListingsLoading,
   filterFunction,
   sortCompareFunction,
   emptyTitle,
   emptyMessage,
-  user,
   showNotifSub,
 }: ContentProps) => {
-  if (!!(!user || !forYou || forYou.length === 0))
-    return (
-      <Flex className="ph-no-capture" direction={'column'} rowGap={1}>
-        {isListingsLoading ? (
-          Array.from({ length: 8 }, (_, index) => (
-            <ListingCardSkeleton key={index} />
-          ))
-        ) : !!bounties?.filter(filterFunction).length ? (
-          bounties
-            .filter(filterFunction)
-            .sort(sortCompareFunction ? sortCompareFunction : () => 0)
-            .slice(0, take ? take + 1 : undefined)
-            .map((bounty) => <ListingCard key={bounty.id} bounty={bounty} />)
-        ) : (
-          <Flex align="center" justify="center" mt={8}>
-            <EmptySection
-              showNotifSub={showNotifSub}
-              title={emptyTitle}
-              message={emptyMessage}
-            />
-          </Flex>
-        )}
-      </Flex>
-    );
   return (
-    <Box>
-      {!!forYou?.filter(filterFunction).length && (
-        <Box
-          mb={4}
-          pb={4}
-          borderColor="brand.slate.200"
-          borderBottomWidth={'1px'}
-        >
-          <Flex
-            align="center"
-            gap={3}
-            w="fit-content"
-            mb={2}
-            color="gray.900"
-            fontWeight={600}
-          >
-            <Text flex={1}>为您推荐</Text>
-            <Box color="gray.500">
-              <Tooltip
-                label={`List of top opportunities curated for you, based on your skills, listing subscriptions and location.`}
-              >
-                <InfoOutlineIcon w={3} h={3} />
-              </Tooltip>
-            </Box>
-          </Flex>
-          <Flex className="ph-no-capture" direction={'column'} rowGap={1}>
-            {isListingsLoading
-              ? Array.from({ length: 8 }, (_, index) => (
-                <ListingCardSkeleton key={index} />
-              ))
-              : forYou
-                .filter(filterFunction)
-                .sort(sortCompareFunction ? sortCompareFunction : () => 0)
-                .slice(0, take ? take + 1 : undefined)
-                .map((bounty) => (
-                  <ListingCard key={bounty.id} bounty={bounty} />
-                ))}
-          </Flex>
-        </Box>
-      )}
-      <Box>
-        <Text mb={2} color="gray.900" fontWeight={600}>
-          所有{title}
-        </Text>
-        <Flex className="ph-no-capture" direction={'column'} rowGap={1}>
-          {isListingsLoading ? (
-            Array.from({ length: 8 }, (_, index) => (
-              <ListingCardSkeleton key={index} />
-            ))
-          ) : !!bounties?.filter(filterFunction).length ? (
-            bounties
-              .filter(filterFunction)
-              .sort(sortCompareFunction ? sortCompareFunction : () => 0)
-              .slice(0, take ? take + 1 : undefined)
-              .map((bounty) => <ListingCard key={bounty.id} bounty={bounty} />)
-          ) : (
-            <Flex align="center" justify="center" mt={8}>
-              <EmptySection
-                showNotifSub={showNotifSub}
-                title={emptyTitle}
-                message={emptyMessage}
-              />
-            </Flex>
-          )}
+    <Flex className="ph-no-capture" direction={'column'} rowGap={1}>
+      {isListingsLoading ? (
+        Array.from({ length: 8 }, (_, index) => (
+          <ListingCardSkeleton key={index} />
+        ))
+      ) : !!bounties?.filter(filterFunction).length ? (
+        bounties
+          .filter(filterFunction)
+          .sort(sortCompareFunction ? sortCompareFunction : () => 0)
+          .slice(0, take ? take + 1 : undefined)
+          .map((bounty) => <ListingCard key={bounty.id} bounty={bounty} />)
+      ) : (
+        <Flex align="center" justify="center" mt={8}>
+          <EmptySection
+            showNotifSub={showNotifSub}
+            title={emptyTitle}
+            message={emptyMessage}
+          />
         </Flex>
-      </Box>
-    </Box>
+      )}
+    </Flex>
   );
 };
 
 export const ListingTabs = ({
   isListingsLoading,
   bounties,
-  forYou,
   take,
   emoji,
   title,
@@ -171,7 +90,6 @@ export const ListingTabs = ({
   showViewAll = false,
   showNotifSub = true,
 }: ListingTabsProps) => {
-  const { user } = useUser();
   const router = useRouter();
   const tabs: TabProps[] = [
     {
@@ -179,10 +97,7 @@ export const ListingTabs = ({
       title: '进行中',
       posthog: 'open_listings',
       content: generateTabContent({
-        user,
-        title: '进行中',
         bounties: bounties,
-        forYou: forYou,
         take,
         isListingsLoading,
         filterFunction: (bounty) =>
@@ -200,10 +115,7 @@ export const ListingTabs = ({
       title: '审核中',
       posthog: 'in review_listing',
       content: generateTabContent({
-        user,
-        title: '审核中',
         bounties: bounties,
-        forYou: forYou,
         take,
         isListingsLoading,
         filterFunction: (bounty) =>
@@ -220,10 +132,7 @@ export const ListingTabs = ({
       title: '已完成',
       posthog: 'completed_listing',
       content: generateTabContent({
-        user,
-        title: '已完成',
         bounties: bounties,
-        forYou: forYou,
         take,
         isListingsLoading,
         filterFunction: (bounty) => bounty.isWinnersAnnounced || false,
@@ -309,7 +218,9 @@ export const ListingTabs = ({
       tab2: 'in review_listing',
       tab3: 'completed_listing',
     };
-    posthog.capture(tabParamMap[activeTab]);
+    if (tabParamMap[activeTab]) {
+      posthog.capture(tabParamMap[activeTab]);
+    }
   }, [activeTab, posthog]);
 
   // Generate view all link with current tab parameter

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -92,6 +92,7 @@ export const authOptions: NextAuthOptions = {
   pages: {
     verifyRequest: '/verify-request',
     newUser: '/api/auth/new-user',
+    error: '/auth/error',
   },
   secret: process.env.NEXTAUTH_SECRET,
 };

--- a/src/pages/auth/error.tsx
+++ b/src/pages/auth/error.tsx
@@ -1,0 +1,145 @@
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  Circle,
+  Flex,
+  Heading,
+  Image,
+  Link,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+import NextLink from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+import { EmailIcon } from '@/svg/email';
+
+// NextAuth 错误类型映射
+const errorMessages: Record<
+  string,
+  { title: string; description: string; action: string }
+> = {
+  Verification: {
+    title: '验证失败',
+    description:
+      '验证码无效或已过期。请返回重新输入验证码，或重新发送新的验证码。',
+    action: '返回验证页面',
+  },
+  AccessDenied: {
+    title: '访问被拒绝',
+    description: '您没有权限访问此资源。请联系管理员或使用其他账户登录。',
+    action: '返回首页',
+  },
+  Configuration: {
+    title: '配置错误',
+    description: '认证服务配置有误。请稍后再试或联系技术支持。',
+    action: '返回首页',
+  },
+  Default: {
+    title: '认证错误',
+    description: '登录过程中出现了未知错误。请稍后重试或联系技术支持。',
+    action: '返回首页',
+  },
+};
+
+export default function AuthError() {
+  const router = useRouter();
+  const [errorType, setErrorType] = useState('Default');
+
+  useEffect(() => {
+    const { error } = router.query;
+    if (error && typeof error === 'string') {
+      setErrorType(errorMessages[error] ? error : 'Default');
+    }
+  }, [router.query]);
+
+  const errorInfo = errorMessages[errorType] || errorMessages.Default;
+
+  const handleAction = () => {
+    if (errorType === 'Verification') {
+      // 验证错误返回验证页面
+      router.push('/verify-request');
+    } else {
+      // 其他错误返回首页
+      router.push('/');
+    }
+  };
+
+  return (
+    <>
+      <Box py={3} borderBottomWidth={2}>
+        <Link as={NextLink} mx="auto" href="/">
+          <Image
+            h={6}
+            mx="auto"
+            cursor="pointer"
+            objectFit={'contain'}
+            alt={'Solar Earn'}
+            onClick={() => {
+              router.push('/');
+            }}
+            src={'/assets/logo/logo-light.png'}
+          />
+        </Link>
+      </Box>
+      <Flex
+        align="center"
+        justify="center"
+        direction="column"
+        minH="70vh"
+        px={3}
+      >
+        <VStack w="full" maxW="md" spacing={6}>
+          <VStack textAlign="center" spacing={3}>
+            <Heading color="#1E293B" fontSize={{ base: '2xl', md: '28' }}>
+              {errorInfo?.title || '认证错误'}
+            </Heading>
+            <Text color="#475569" fontSize={{ base: 'lg', md: '20' }}>
+              认证过程中发生了错误
+            </Text>
+          </VStack>
+
+          <Circle bg="#FEF2F2" size={32}>
+            <EmailIcon />
+          </Circle>
+
+          <Alert borderRadius="md" status="error">
+            <AlertIcon />
+            <Box>
+              <Text fontSize="sm" fontWeight="medium">
+                {errorInfo?.description || '登录过程中出现了未知错误。'}
+              </Text>
+            </Box>
+          </Alert>
+
+          <VStack w="full" spacing={3}>
+            <Button
+              w="full"
+              colorScheme="purple"
+              onClick={handleAction}
+              size="lg"
+            >
+              {errorInfo?.action || '返回首页'}
+            </Button>
+
+            <Button
+              w="full"
+              onClick={() => router.push('/')}
+              size="sm"
+              variant="ghost"
+            >
+              返回首页
+            </Button>
+
+            <Text maxW="sm" color="#94A3B8" fontSize="xs" textAlign="center">
+              如果问题持续存在，请联系技术支持团队。
+            </Text>
+          </VStack>
+        </VStack>
+      </Flex>
+    </>
+  );
+}

--- a/src/pages/verify-request.tsx
+++ b/src/pages/verify-request.tsx
@@ -85,12 +85,25 @@ export default function VerifyRequest() {
         },
       );
 
-      // 检查响应状态
-      if (response.status === 200 || response.status === 0) {
-        // 验证成功，跳转
+      // 更精确的验证结果判断
+      if (response.status === 200) {
+        // 直接验证成功 (不太可能，NextAuth通常返回重定向)
+        window.location.href = `/api/auth/callback/email?token=${token}&email=${encodedEmail}`;
+      } else if (response.status === 302 || response.status === 307) {
+        // 检查重定向目标
+        const location = response.headers.get('Location');
+        if (location && location.includes('/auth/error')) {
+          // 重定向到错误页面 = 验证失败
+          handleVerificationError();
+        } else {
+          // 重定向到其他页面 = 验证成功
+          window.location.href = `/api/auth/callback/email?token=${token}&email=${encodedEmail}`;
+        }
+      } else if (response.status === 0) {
+        // 可能是 CORS 或网络问题，尝试直接跳转
         window.location.href = `/api/auth/callback/email?token=${token}&email=${encodedEmail}`;
       } else {
-        // 验证失败
+        // 其他状态码 = 验证失败
         handleVerificationError();
       }
     } catch (error) {
@@ -274,7 +287,7 @@ export default function VerifyRequest() {
 
             <Button
               w="full"
-              isDisabled={!canResend || resendCooldown > 0 || timeLeft === 0}
+              isDisabled={!canResend || resendCooldown > 0}
               onClick={handleResendCode}
               size="sm"
               variant="outline"


### PR DESCRIPTION

  ### 增加错误配置页面

#### 第一道防线（用户看到的）：
  // verify-request.tsx 中的逻辑
  if (location && location.includes('/auth/error')) {
    handleVerificationError(); // 红色提示："验证码错误，剩余X次"
  }
  ####  第二道防线（兜底保障）：
  // 自定义配置错误页面
  pages: {
    error: '/auth/error', // 中文友好页面
  }


### 为您推荐 移除

界面会保持简洁，只显示三个标签页（进行中、审核中、已完成），每个标签页直接显示所有符合条件的任务，不再有个性化推荐的区块。

  主要修改：
  1. src/features/listings/components/ListingTabs.tsx:68-90 - 简化了generateTabContent函数，移除了推荐逻辑
  2. 清理了未使用的imports和参数（InfoOutlineIcon、Tooltip、User、useUser等）
  3. 移除了对forYou和user参数的依赖

